### PR TITLE
Disable root command for Dropbox up loader.

### DIFF
--- a/scripts/docker_backup.sh
+++ b/scripts/docker_backup.sh
@@ -16,7 +16,10 @@ sudo tar -czf \
 ./backups/influxdb
 echo "backup saved to ./backups/docker.tar.gz"
 
-#echo "uploading to dropbox
-#sudo ~/Dropbox-Uploader/dropbox_uploader.sh upload ~/IOTstack/backups/docker.tar.gz /IOTstackBU/
+#cp ~/IOTstack/backups/docker.tar.gz ~
+#echo "uploading to dropbox"
+#~/Dropbox-Uploader/dropbox_uploader.sh upload /home/pi/docker.tar.gz /IOTstackBU/
+#rm /home/pi/docker.tar.gz
+
 
 popd


### PR DESCRIPTION
Not sure if this is better but I had some problems with the uploader.  So to make things "easier" I changed the script so that the backup file gets copied to the home folder then you can upload the file without root permission. Thereafter delete temp file.