### PR TITLE
Appended date to backup file and keeps only the last five backups

### DIFF
--- a/scripts/docker_backup.sh
+++ b/scripts/docker_backup.sh
@@ -5,36 +5,38 @@ pushd ~/IOTstack
 [ -d ./backups ] || mkdir ./backups
 
 #create the list of files to backup
-echo "./docker-compose.yml" >list.txt
-echo "./services/" >>list.txt
-echo "./volumes/" >>list.txt
+echo "./docker-compose.yml" > list.txt
+echo "./services/" >> list.txt
+echo "./volumes/" >> list.txt
 
 #if influxdb folder exists then back it up
 if [ -d ./volumes/influxdb ]; then
-	./scripts/backup_influxdb.sh
-	echo "./backups/influxdb/" >>list.txt
+    ./scripts/backup_influxdb.sh
+    echo "./backups/influxdb/" >> list.txt
 fi
+
+DATE=$(date +"%Y-%m-%d_%H%M")
 
 echo "compressing stack folders"
 sudo tar -czf \
-	./backups/"backup-$(date +"%Y-%m-%d").tar.gz" \
-	--exclude=./volumes/influxdb/* \
-	-T list.txt
+./backups/"backup-$DATE.tar.gz" \
+--exclude=./volumes/influxdb/* \
+-T list.txt
 
 rm list.txt
 
-echo "backup saved to ./backups/"backup-$(date +"%Y-%m-%d").tar.gz""
+echo "backup saved to ./backups/backup-$DATE.tar.gz"
 
-du -h ./backups/"backup-$(date +"%Y-%m-%d").tar.gz"
+du -h ./backups/"backup-$DATE.tar.gz"
 
 if [ -f ./backups/dropbox ]; then
-	echo "uploading to dropbox"
-	~/Dropbox-Uploader/dropbox_uploader.sh upload ./backups/"backup-$(date +"%Y-%m-%d").tar.gz" /IOTstackBU/
+    echo "uploading to dropbox"
+    ~/Dropbox-Uploader/dropbox_uploader.sh upload ./backups/"backup-$DATE.tar.gz" /IOTstackBU/
 fi
 
 if [ -f ./backups/rclone ]; then
-	echo "uploading to Google Drive"
-	rclone -P copy ./backups/"backup-$(date +"%Y-%m-%d").tar.gz" gdrive:/IOTstackBU/
+    echo "uploading to Google Drive"
+    rclone -P copy ./backups/"backup-$DATE.tar.gz" gdrive:/IOTstackBU/
 fi
 
 ls -t1 ./backups/backup* | tail -n +6 | sudo xargs rm -f

--- a/scripts/docker_backup.sh
+++ b/scripts/docker_backup.sh
@@ -37,4 +37,7 @@ if [ -f ./backups/rclone ]; then
 	rclone -P copy ./backups/"backup-$(date +"%Y-%m-%d").tar.gz" gdrive:/IOTstackBU/
 fi
 
+ls -t1 ./backups/backup* | tail -n +6 | sudo xargs rm -f
+echo "last five backup files are saved in ~/IOTstack/backups"
+
 popd

--- a/scripts/docker_backup.sh
+++ b/scripts/docker_backup.sh
@@ -17,24 +17,24 @@ fi
 
 echo "compressing stack folders"
 sudo tar -czf \
-	./backups/docker.tar.gz \
+	./backups/"backup-$(date +"%Y-%m-%d").tar.gz" \
 	--exclude=./volumes/influxdb/* \
 	-T list.txt
 
 rm list.txt
 
-echo "backup saved to ./backups/docker.tar.gz"
+echo "backup saved to ./backups/"backup-$(date +"%Y-%m-%d").tar.gz""
 
-du -h ./backups/docker.tar.gz
+du -h ./backups/"backup-$(date +"%Y-%m-%d").tar.gz"
 
 if [ -f ./backups/dropbox ]; then
 	echo "uploading to dropbox"
-	~/Dropbox-Uploader/dropbox_uploader.sh upload ~/IOTstack/backups/docker.tar.gz /IOTstackBU/
+	~/Dropbox-Uploader/dropbox_uploader.sh upload ./backups/"backup-$(date +"%Y-%m-%d").tar.gz" /IOTstackBU/
 fi
 
 if [ -f ./backups/rclone ]; then
 	echo "uploading to Google Drive"
-	rclone -P copy ./backups/docker.tar.gz gdrive:/IOTstackBU/
+	rclone -P copy ./backups/"backup-$(date +"%Y-%m-%d").tar.gz" gdrive:/IOTstackBU/
 fi
 
 popd


### PR DESCRIPTION
Hi,

Hopefully this is of some use, if you have a better solution I would be interested.

I have done the following:

- Appended date stamp to backup file, YYYY-MM-DD so they appear in correct order.
- Delete all backup files except the five most recent.

To do:  Dropbox currently gets a copy of all files, look at how to remove older files if possible.