### PR TITLE
Corrects backup script permissions problem introduced by commit 53d9cde

### DIFF
--- a/scripts/docker_backup.sh
+++ b/scripts/docker_backup.sh
@@ -32,7 +32,8 @@ sudo chown pi:pi ./backups/backup*
 
 #create log file and add the backup file to it
 echo "backup saved to ./backups/$backupfile"
-touch $logfile
+sudo touch $logfile
+sudo chown pi:pi $logfile
 echo $backupfile >>$logfile
 
 #show size of archive file


### PR DESCRIPTION
docker_backup.sh contains embedded "sudo" commands so the intention
seems to be that the script should not be run as root. The unprivileged
"touch" command to create the log file in the backups directory fails
because the directory has root ownership. The backup files (.tar.gz) are
given user ownership so the log file should probably have matching user
ownership. This PR reinstates "sudo touch $logfile" but then changes
$logfile ownership to pi:pi before the backup file name is echoed to
the log file.