### PR TITLE
added support for diyhue

### DIFF
--- a/.templates/diyhue/diyhue.env
+++ b/.templates/diyhue/diyhue.env
@@ -1,0 +1,2 @@
+IP=your_Pi's_IP_here
+MAC=your_Pi's_MAC_here

--- a/.templates/diyhue/service.yml
+++ b/.templates/diyhue/service.yml
@@ -1,0 +1,14 @@
+  diyhue:
+    container_name: diyhue
+    image: diyhue/core:latest
+    ports:
+      - "8070:80/tcp"
+      - "1900:1900/udp"
+      - "1982:1982/udp"
+      - "2100:2100/udp"
+      # - "443:443/tcp"
+    env_file:
+      - ./services/diyhue/diyhue.env
+    volumes:
+       - ./volumes/diyhue/:/opt/hue-emulator/export/
+    restart: unless-stopped

--- a/menu.sh
+++ b/menu.sh
@@ -25,11 +25,12 @@ declare -A cont_array=(
 	[blynk_server]="blynk-server"
 	[nextcloud]="Next-Cloud"
 	[nginx]="NGINX by linuxserver"
+	[diyhue]="diyHue"
 
 )
 declare -a armhf_keys=("portainer" "nodered" "influxdb" "grafana" "mosquitto" "telegraf" "mariadb" "postgres"
 	"adminer" "openhab" "zigbee2mqtt" "pihole" "plex" "tasmoadmin" "rtl_433" "espruinohub"
-	"motioneye" "webthings_gateway" "blynk_server" "nextcloud")
+	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue")
 
 sys_arch=$(uname -m)
 


### PR DESCRIPTION
This PR adds support for [diyHue](https://diyhue.org). The Ip and Mac address of the host must be specified in the .env file. 