### PR TITLE
Adds a Gitea container to IOTstack

### DIFF
--- a/.templates/gitea/gitea.env
+++ b/.templates/gitea/gitea.env
@@ -1,0 +1,1 @@
+# initially empty

--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -1,0 +1,14 @@
+  gitea:
+    container_name: gitea
+    image: kapdap/gitea-rpi
+    restart: unless-stopped
+    user: "0"
+    ports:
+      - "7920:3000/tcp"
+      - "2222:22/tcp"
+    env_file:
+      - ./services/gitea/gitea.env
+    volumes:
+      - ./volumes/gitea/data:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro

--- a/menu.sh
+++ b/menu.sh
@@ -28,11 +28,12 @@ declare -A cont_array=(
 	[diyhue]="diyHue"
 	[homebridge]="Homebridge"
 	[python]="Python 3"
+	[gitea]="Gitea"
 
 )
 declare -a armhf_keys=("portainer" "nodered" "influxdb" "grafana" "mosquitto" "telegraf" "mariadb" "postgres"
 	"adminer" "openhab" "zigbee2mqtt" "pihole" "plex" "tasmoadmin" "rtl_433" "espruinohub"
-	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue" "homebridge" "python")
+	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue" "homebridge" "python" "gitea")
 
 sys_arch=$(uname -m)
 


### PR DESCRIPTION
Gitea is a lightweight implementation of a Git server. Makers who are
already running a local IOTstack server may prefer to commit their work
to a local repository running on their Raspberry Pi, rather than
GitHub/GitLab/etc. Implementing Gitea under the IOTStack umbrella
inherits the existing IOTstack backup mechanisms for free.

Candidate page for the wiki at
https://www.dropbox.com/s/onqndgyamo2h74i/Gitea.md.zip?dl=1