### PR TITLE
Remove docker-compose down b/c it is not needed and adds downtime

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-echo "Stopping containers"
-docker-compose down
-
 echo "Downloading latest images from docker hub ... this can take a long time"
 docker-compose pull
 


### PR DESCRIPTION
The docker update process can be performed with the containers active. The `docker-compose up` process automatically replaces any old container, even if it is still active. This means that there is nearly zero downtime.

So instead of shutting contains down before pulling and building updates (a lengthy process), the current containers can continue performing tasks, only being replaced when any updates have finished being processed.

The `docker-compose build` line could also be integrated into the up process via a flag: `docker-compose up -d --build`, however, that may obscure the flow of things hence I didn't propose it.