### PR TITLE
Configuration adjustments

### DIFF
--- a/.templates/mosquitto/mosquitto.conf
+++ b/.templates/mosquitto/mosquitto.conf
@@ -2,3 +2,5 @@ persistence true
 persistence_location /mosquitto/data/
 log_dest file /mosquitto/log/mosquitto.log
 #password_file /mosquitto/config/pwfile
+listener 1883
+allow_anonymous true

--- a/.templates/zigbee2mqtt/service.yml
+++ b/.templates/zigbee2mqtt/service.yml
@@ -7,6 +7,7 @@
     devices:
       - /dev/ttyAMA0:/dev/ttyACM0
       #- /dev/ttyACM0:/dev/ttyACM0
+      #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
     restart: always
     network_mode: host
     privileged: true


### PR DESCRIPTION
The following configuration adjustment will make Mosquitto work by default. It is assumed that users who will set their password will disable anonymous access anyway. This config will work by default with out a password.

Also adding a note about a configuration setting for zigbee2mqtt with Electrolama dongle